### PR TITLE
[NIFI-10630] Fixed Possible Json Ordering Permutations Problem in Tests

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestWaitNotifyProtocol.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestWaitNotifyProtocol.java
@@ -107,7 +107,7 @@ public class TestWaitNotifyProtocol {
 
         ObjectMapper mapper = new ObjectMapper();
         assertEquals(1, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":1},\"attributes\":{},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":1},\"attributes\":{},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
     }
 
@@ -126,14 +126,14 @@ public class TestWaitNotifyProtocol {
         ObjectMapper mapper = new ObjectMapper();
         AtomicCacheEntry<String, String, Long> cacheEntry = cacheEntries.get("signal-id");
         assertEquals(2, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":2},\"attributes\":{},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":2},\"attributes\":{},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
 
         protocol.notify(signalId, "a", 10, null);
 
         cacheEntry = cacheEntries.get("signal-id");
         assertEquals(3, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":12},\"attributes\":{},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":12},\"attributes\":{},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
 
         protocol.notify(signalId, "b", 2, null);
@@ -141,7 +141,7 @@ public class TestWaitNotifyProtocol {
 
         cacheEntry = cacheEntries.get("signal-id");
         assertEquals(5, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":12,\"b\":2,\"c\":3},\"attributes\":{},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":12,\"b\":2,\"c\":3},\"attributes\":{},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
 
         final Map<String, Integer> deltas = new HashMap<>();
@@ -151,14 +151,14 @@ public class TestWaitNotifyProtocol {
 
         cacheEntry = cacheEntries.get("signal-id");
         assertEquals(6, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":22,\"b\":27,\"c\":3},\"attributes\":{},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":22,\"b\":27,\"c\":3},\"attributes\":{},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
 
         // Zero clear 'b'.
         protocol.notify("signal-id", "b", 0, null);
         cacheEntry = cacheEntries.get("signal-id");
         assertEquals(7, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":22,\"b\":0,\"c\":3},\"attributes\":{},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":22,\"b\":0,\"c\":3},\"attributes\":{},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
 
     }
@@ -180,7 +180,7 @@ public class TestWaitNotifyProtocol {
         ObjectMapper mapper = new ObjectMapper();
         AtomicCacheEntry<String, String, Long> cacheEntry = cacheEntries.get("signal-id");
         assertEquals(1L, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":1},\"attributes\":{\"p1\":\"a1\",\"p2\":\"a1\"},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":1},\"attributes\":{\"p1\":\"a1\",\"p2\":\"a1\"},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()));
 
         final Map<String, String> attributeA2 = new HashMap<>();
@@ -192,7 +192,7 @@ public class TestWaitNotifyProtocol {
 
         cacheEntry = cacheEntries.get("signal-id");
         assertEquals(2L, cacheEntry.getRevision().orElse(-1L).longValue());
-        assertEquals(mapper.readTree("{\"counts\":{\"a\":2},\"attributes\":{\"p1\":\"a1\",\"p2\":\"a2\",\"p3\":\"a2\"},\"releasableCount\":0}"), 
+        assertEquals(mapper.readTree("{\"counts\":{\"a\":2},\"attributes\":{\"p1\":\"a1\",\"p2\":\"a2\",\"p3\":\"a2\"},\"releasableCount\":0}"),
         mapper.readTree(cacheEntry.getValue()),"Updated attributes should be merged correctly");
 
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10630](https://issues.apache.org/jira/browse/NIFI-10630)
Following the problem of flakiness that occurred in test file
`nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors org.apache.nifi.processors.standard.TestWaitNotifyProtocol`
with below three tests
```
testNotifyAttributes
testNotifyCounters
testNotifyFirst
```
The test flakiness is due to comparisons between Json Strings and outputs from
`cacheEntry.getValue()` which is an Object `AtomicCacheEntry<String, String, Long>`

However, JsonObject does not guarantee entry orders, its object is an unordered set of name/value pairs, and internal permutations may occur in the output as JSON String.

## Brief changelog

Since JSON library `com.fasterxml.jackson.databind` is used in the current project, I import the `ObjectMapper`and use `mapper.readTree(JSON String)` when comparing them, thus the equals() method ignores the order and treats them as equal.

## Verifying this change

This test avoids nested or different orders of JSON strings that cause flaky errors.
Since I didn't touch any Source code, it should be no impact on the project.
And it passed the local test that the guidelines mentioned.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [X] JDK 11
  - [ ] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
